### PR TITLE
Update gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,6 @@ gulp.task("browser-sync", function(){
 
 gulp.task("nodemon", function(){
     nodemon({
-        exec: 'node --debug',
         script: 'app.js',
         ignore: ["public/*"],
         debug: true


### PR DESCRIPTION
Causing multiple instances to run debug due multithreading in app.js. nodemon fails to open socket at 5858 since already open by other instance thread.